### PR TITLE
Update Southern_Water_Corp_OLS_Case_Study_Student_Facing.ipynb

### DIFF
--- a/Southern_Water_Corp_OLS_Case_Study_Student_Facing.ipynb
+++ b/Southern_Water_Corp_OLS_Case_Study_Student_Facing.ipynb
@@ -351,13 +351,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---------------------------------------------------------------------------"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Step 4: <span style=\"color:green\">Filtered Dataframes with Box Plots</span> \n",
     "\n",
     "i) Using the dataframe_raw dataset, create two boxplots specifically for when the Pump has failed (i.e. Pump Failure = 1)  and 0 (Pump is in normal operations). \n",


### PR DESCRIPTION
Change the About/Description for this project to say simply say - (Don't add any less or more words)

Case Study Challenge analysis for a Southern Water Corp via Python and Jupyter

Don't need to go in the about/description. Future employers just want to get a simple understanding. And I believe the many point of this project was to show you understand the fundamentals and you now you have the experience.

There should be a nice README.md to all your projects to explain what you are accomplishing and the technologies used. Be brief in your README.md. Not too long winded.